### PR TITLE
Do not specify options multiple times

### DIFF
--- a/lib/App/Cme/Command/check.pm
+++ b/lib/App/Cme/Command/check.pm
@@ -22,7 +22,8 @@ sub validate_args {
 sub opt_spec {
     my ( $class, $app ) = @_;
     return ( 
-        [ "strict!" => "cme will exit 1 if warnings are found during check" ],
+        [ "strict!"     => "cme will exit 1 if warnings are found during check" ],
+        [ "verbose!"    => "Show what's going on"],
         $class->cme_global_options,
     );
 }

--- a/lib/App/Cme/Command/dump.pm
+++ b/lib/App/Cme/Command/dump.pm
@@ -39,6 +39,9 @@ sub opt_spec {
                 default => 'yaml'
             },
         ],
+        [
+            "verbose!" => "Show what's going on"
+        ],
         $class->cme_global_options,
     );
 }

--- a/lib/App/Cme/Command/edit.pm
+++ b/lib/App/Cme/Command/edit.pm
@@ -24,6 +24,7 @@ sub opt_spec {
         [ "ui|if=s"     => "user interface type. Either tk, curses, shell" ],
         [ "backup:s"  => "Create a backup of configuration files before saving." ],
         [ "open-item=s" => "open a specific item of the configuration" ],
+        [ "verbose!"    => "Show what's going on" ],
         $class->cme_global_options,
     );
 }

--- a/lib/App/Cme/Command/fix.pm
+++ b/lib/App/Cme/Command/fix.pm
@@ -24,6 +24,7 @@ sub opt_spec {
         [ "from=s@"  => "fix only a subset of a configuration tree" ],
         [ "backup:s"  => "Create a backup of configuration files before saving." ],
         [ "filter=s" => "pattern to select the element name to be fixed"],
+        [ "verbose!" => "Show what's going on" ],
         $class->cme_global_options,
     );
 }

--- a/lib/App/Cme/Command/fusefs.pm
+++ b/lib/App/Cme/Command/fusefs.pm
@@ -38,6 +38,7 @@ sub opt_spec {
         [ "dfuse!"     => "debug fuse problems" ],
         [ "dir-char=s" => "string to replace '/' in configuration parameter names"],
         [ "backup:s"  => "Create a backup of configuration files before saving." ],
+        [ "verbose!"  => "Show what's going on" ],
         $class->cme_global_options,
     );
 }

--- a/lib/App/Cme/Command/migrate.pm
+++ b/lib/App/Cme/Command/migrate.pm
@@ -22,6 +22,7 @@ sub opt_spec {
     my ( $class, $app ) = @_;
     return (
         [ "backup:s"  => "Create a backup of configuration files before saving." ],
+        [ "verbose!"  => "Show what's going on" ],
         $class->cme_global_options,
     );
 }

--- a/lib/App/Cme/Command/search.pm
+++ b/lib/App/Cme/Command/search.pm
@@ -29,6 +29,9 @@ sub opt_spec {
             "narrow-search=s" => "narrows down the search to element, value, key, summary, description or help",
             { regex => qr/^(?:element|value|key|summary|description|help|all)$/, default => 'all' }
         ],
+        [
+            "verbose!"        => "Show what's going on"
+        ],
         $class->cme_global_options,
     );
 }

--- a/lib/App/Cme/Command/shell.pm
+++ b/lib/App/Cme/Command/shell.pm
@@ -22,6 +22,7 @@ sub opt_spec {
         [ "open-item=s" => "open a specific item of the configuration" ],
         [ "backup:s"  => "Create a backup of configuration files before saving." ],
         [ "bare!"       => "run bare terminal UI"],
+        [ "verbose!"    => "Show what's going on" ],
         $class->cme_global_options,
     );
 }

--- a/lib/App/Cme/Command/update.pm
+++ b/lib/App/Cme/Command/update.pm
@@ -25,6 +25,7 @@ sub opt_spec {
     return ( 
         [ "edit!"     => "Run editor after update is done" ],
         [ "backup:s"  => "Create a backup of configuration files before saving." ],
+        [ "verbose!"  => "Show what's going on" ],
         $class->cme_global_options,
     );
 }

--- a/lib/App/Cme/Common.pm
+++ b/lib/App/Cme/Common.pm
@@ -33,7 +33,6 @@ sub cme_global_options {
       # to be deprecated
       [ "canonical!"         => "write back config data according to canonical order" ],
       [ "trace|stack-trace!" => "Provides a full stack trace when exiting on error"],
-      [ "verbose!"           => "Show what's going on"],
       [ "quiet"              => "Suppress all output except error messages"],
       # no bundling
       { getopt_conf => [ qw/no_bundling/ ] }


### PR DESCRIPTION
Getopt::Long::Descriptive 0.106 started to warn about duplicate
options. This patch pull request fixes it by moving the verbose option to each command.

<https://github.com/dod38fr/cme-perl/issues/5>